### PR TITLE
unicorn: bring up to version 5.2.0

### DIFF
--- a/lib/unicorn/configurator.rb
+++ b/lib/unicorn/configurator.rb
@@ -41,6 +41,7 @@ class Unicorn::Configurator
     :before_exec => lambda { |server|
         server.logger.info("forked child re-executing...")
       },
+    :before_murder => nil,
     :pid => nil,
     :preload_app => false,
     :check_client_connection => false,
@@ -166,6 +167,14 @@ class Unicorn::Configurator
   # There is no corresponding after_exec hook (for obvious reasons).
   def before_exec(*args, &block)
     set_hook(:before_exec, block_given? ? block : args[0], 1)
+  end
+
+  # Sets the before_murder hook to a gien Proc object. This Proc object
+  # will be called by the master process before killing a lazy worker
+  # with SIGKILL, the point of this callback is NOT to prevent killing
+  # but to provide an instrumentation hook
+  def before_murder(*args, &block)
+    set_hook(:before_murder, block_given? ? block : args[0], 1)
   end
 
   # sets the timeout of worker processes to +seconds+.  Workers

--- a/lib/unicorn/configurator.rb
+++ b/lib/unicorn/configurator.rb
@@ -169,12 +169,27 @@ class Unicorn::Configurator
     set_hook(:before_exec, block_given? ? block : args[0], 1)
   end
 
-  # Sets the before_murder hook to a gien Proc object. This Proc object
+  # Sets the before_murder hook to a given Proc object. This Proc object
   # will be called by the master process before killing a lazy worker
   # with SIGKILL, the point of this callback is NOT to prevent killing
   # but to provide an instrumentation hook
   def before_murder(*args, &block)
-    set_hook(:before_murder, block_given? ? block : args[0], 1)
+    set_hook_arg = if block_given?
+      # This hook is meant a an instrumentation point, it should not prevent the
+      # worker from getting killed exception will be logged and move on
+      new_block = Proc.new do |server, worker, wpid|
+        begin
+          block.call(server, worker, wpid)
+        rescue StandardError => e
+          server.logger.error("Error executing before murder for PID: #{wpid} error: #{e.inspect}")
+          server.logger.error(e.backtrace.join("\n"))
+        end
+      end
+    else
+      args[0]
+    end
+
+    set_hook(:before_murder, set_hook_arg, 3)
   end
 
   # sets the timeout of worker processes to +seconds+.  Workers

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -479,7 +479,7 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      if before_murder and not @before_murder_called.include?(wpid)
+      if before_murder && !@before_murder_called.include?(wpid)
         before_murder.call(self, worker, wpid)
         @before_murder_called.add(wpid) # This ensures we call before_murder only once
       end

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -476,7 +476,7 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      before_murder.call(wpid) if before_murder
+      before_murder.call(self, worker, wpid) if before_murder
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -14,7 +14,8 @@ class Unicorn::HttpServer
   attr_accessor :app, :timeout, :worker_processes,
                 :before_fork, :after_fork, :before_exec,
                 :listener_opts, :preload_app,
-                :orig_app, :config, :ready_pipe, :user
+                :orig_app, :config, :ready_pipe, :user,
+                :before_murder
 
   attr_reader :pid, :logger
   include Unicorn::SocketHelper
@@ -475,6 +476,7 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
+      before_murder.call(wpid) if before_murder
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -90,7 +90,7 @@ class Unicorn::HttpServer
     @self_pipe = []
     @workers = {} # hash maps PIDs to Workers
     @sig_queue = [] # signal queue used for self-piping
-    @before_murder_called = Set.new() # ensures before_murder is called only once
+    @before_murder_called = Set.new # ensures before_murder is called only once
 
     # we try inheriting listeners first, so we bind them later.
     # we don't write the pid file until we've bound listeners in case
@@ -479,10 +479,8 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      if before_murder && !@before_murder_called.include?(wpid)
-        before_murder.call(self, worker, wpid)
-        @before_murder_called.add(wpid) # This ensures we call before_murder only once
-      end
+      # Ensure we call before_murder only once
+      before_murder.call(self, worker, wpid) if before_murder and @before_murder_called.add?(wpid)
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+require 'set'
 
 # This is the process manager of Unicorn. This manages worker
 # processes which in turn handle the I/O and application process.
@@ -89,6 +90,7 @@ class Unicorn::HttpServer
     @self_pipe = []
     @workers = {} # hash maps PIDs to Workers
     @sig_queue = [] # signal queue used for self-piping
+    @before_murder_called = Set.new() # ensures before_murder is called only once
 
     # we try inheriting listeners first, so we bind them later.
     # we don't write the pid file until we've bound listeners in case
@@ -395,6 +397,7 @@ class Unicorn::HttpServer
         self.pid = pid.chomp('.oldbin') if pid
         proc_name 'master'
       else
+        @before_murder_called.delete(wpid)
         worker = @workers.delete(wpid) and worker.close rescue nil
         m = "reaped #{status.inspect} worker=#{worker.nr rescue 'unknown'}"
         status.success? ? logger.info(m) : logger.error(m)
@@ -476,7 +479,10 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      before_murder.call(self, worker, wpid) if before_murder
+      if before_murder and not @before_murder_called.include?(wpid)
+        before_murder.call(self, worker, wpid)
+        @before_murder_called.add(wpid) # This ensures we call before_murder only once
+      end
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep
@@ -689,6 +695,7 @@ class Unicorn::HttpServer
   def kill_worker(signal, wpid)
     Process.kill(signal, wpid)
   rescue Errno::ESRCH
+    @before_murder_called.delete(wpid)
     worker = @workers.delete(wpid) and worker.close rescue nil
   end
 

--- a/t/before_murder.ru
+++ b/t/before_murder.ru
@@ -1,0 +1,7 @@
+use Rack::ContentLength
+use Rack::ContentType, "text/plain"
+app = lambda do |env|
+  Process.kill(:STOP, Process.pid)
+  [ 200, {}, [ "#$$\n" ] ]
+end
+run app

--- a/t/before_murder_once.ru
+++ b/t/before_murder_once.ru
@@ -1,0 +1,7 @@
+use Rack::ContentLength
+use Rack::ContentType, "text/plain"
+app = lambda do |env|
+  Process.kill(:STOP, Process.pid)
+  [ 200, {}, [ "#$$\n" ] ]
+end
+run app

--- a/t/before_murder_once.ru
+++ b/t/before_murder_once.ru
@@ -1,7 +1,0 @@
-use Rack::ContentLength
-use Rack::ContentType, "text/plain"
-app = lambda do |env|
-  Process.kill(:STOP, Process.pid)
-  [ 200, {}, [ "#$$\n" ] ]
-end
-run app

--- a/t/t0023-before-murder.sh
+++ b/t/t0023-before-murder.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+. ./test-lib.sh
+t_plan 5 "before murder is called"
+
+t_begin "setup and start" && {
+	unicorn_setup
+	cat >> $unicorn_config <<EOF
+timeout 5
+after_fork { |s,w| File.open('$fifo','w') { |f| f.write '.' } }
+before_murder do |s, w, p| 
+  \$stderr.puts "before murder called:"
+end
+EOF
+	unicorn -c $unicorn_config before_murder.ru &
+	test '.' = $(cat $fifo)
+	unicorn_wait_start
+}
+
+t_begin "start worker=0" && {
+	pid=$(curl http://$listen/) || true
+}
+
+t_begin "ensure before murder log is present" && {
+	dbgcat r_err
+	grep 'before murder called:' $r_err 
+	dbgcat r_err
+	> $r_err
+}
+
+t_begin "killing succeeds" && {
+  kill $unicorn_pid
+  wait
+  kill -0 $unicorn_pid && false
+}
+
+t_begin "check stderr" && {
+	check_stderr
+}
+
+t_done

--- a/t/t0024-before-murder_once.sh
+++ b/t/t0024-before-murder_once.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+. ./test-lib.sh
+t_plan 5 "before murder is called"
+
+t_begin "setup and start" && {
+	unicorn_setup
+	cat >> $unicorn_config <<EOF
+timeout 5
+after_fork { |s,w| File.open('$fifo','w') { |f| f.write '.' } }
+class Unicorn::HttpServer
+  def kill_worker(signal, wpid)
+    @iteration ||= 0
+    \$stderr.puts "kill_worker #{signal} #{wpid} #{@iteration}"
+    if @iteration > 0 then
+      Process.kill(signal, wpid)
+    end
+    @iteration = @iteration + 1
+  rescue Errno::ESRCH
+    @before_murder_called.delete(wpid)
+    worker = @workers.delete(wpid) and worker.close rescue nil
+  end
+end
+before_murder do |s, w, p| 
+  \$stderr.puts "before murder called:"
+end
+EOF
+	unicorn -c $unicorn_config before_murder.ru &
+	test '.' = $(cat $fifo)
+	unicorn_wait_start
+}
+
+t_begin "start worker=0" && {
+	pid=$(curl http://$listen/) || true
+}
+
+t_begin "ensure before murder log is present once and killing is present twice" && {
+	dbgcat r_err
+	grep 'before murder called:' $r_err 
+  test 1 -eq $(grep "before murder called:" $r_err | count_lines)
+  test 2 -eq $(grep timeout $r_err | grep killing | count_lines)
+  test 2 -eq $(grep "kill_worker KILL" $r_err | count_lines)
+	dbgcat r_err
+	> $r_err
+}
+
+t_begin "killing succeeds" && {
+  kill $unicorn_pid
+  wait
+  kill -0 $unicorn_pid && false
+}
+
+t_begin "check stderr" && {
+	check_stderr
+}
+
+t_done

--- a/t/t0024-before-murder_once.sh
+++ b/t/t0024-before-murder_once.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 . ./test-lib.sh
-t_plan 5 "before murder is called"
+t_plan 5 "before murder is called only once"
 
 t_begin "setup and start" && {
 	unicorn_setup

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -14,7 +14,7 @@ end.compact
 
 Gem::Specification.new do |s|
   s.name = %q{unicorn-camilo}
-  s.version = "4.8.2.5.16"
+  s.version = "4.8.2.5.19"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+ENV["VERSION"] or abort "VERSION= must be specified"
 manifest = File.readlines('.manifest').map! { |x| x.chomp! }
 require 'olddoc'
 extend Olddoc::Gemspec

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -13,7 +13,7 @@ test_files = manifest.grep(%r{\Atest/unit/test_.*\.rb\z}).map do |f|
 end.compact
 
 Gem::Specification.new do |s|
-  s.name = %q{unicorn-camilo}
+  s.name = %q{unicorn-shopify}
   s.version = "4.8.2.5.23"
   s.authors = ["#{name} hackers"]
   s.summary = summary

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -13,8 +13,8 @@ test_files = manifest.grep(%r{\Atest/unit/test_.*\.rb\z}).map do |f|
 end.compact
 
 Gem::Specification.new do |s|
-  s.name = %q{unicorn}
-  s.version = ENV["VERSION"].dup
+  s.name = %q{unicorn-camilo}
+  s.version = "4.8.2.5.16"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -1,5 +1,4 @@
 # -*- encoding: binary -*-
-ENV["VERSION"] or abort "VERSION= must be specified"
 manifest = File.readlines('.manifest').map! { |x| x.chomp! }
 require 'olddoc'
 extend Olddoc::Gemspec

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -14,7 +14,7 @@ end.compact
 
 Gem::Specification.new do |s|
   s.name = %q{unicorn-camilo}
-  s.version = "4.8.2.5.19"
+  s.version = "4.8.2.5.23"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description


### PR DESCRIPTION
We're almost two years out-of-date. This brings us up-to-speed. The changelog seems mostly concerned with internal refactoring, performance improvements and dropping 1.8 support.

@shivnagarajan @csfrancis @camilo have you attempted this before?